### PR TITLE
Add erratum

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We also provide a PDF file that has color images of the screenshots/diagrams use
 
 ## Errata
 * Page 581 (Section 5, heading): **The PostegreSQL System** _should be_ **The PostgreSQL System**
+* Page 82 (Dropping databases, first paragraph): **to drop a table** _should be_ **to drop a database**
 
 ### Related products 
 * Mastering PostgreSQL 12 [[Packt]](https://www.packtpub.com/product/mastering-postgresql-12-third-edition/9781838988821) [[Amazon]](https://www.amazon.com/dp/1838988823)


### PR DESCRIPTION
Hello,

On page 82, in the first paragraph of section *Dropping databases*, the word _table_ should be replaced with _database_.

Actually I would like to know if you prefer updates through PR or through the Packt website. Please let me know @fluca1978 @sscotty71.

Have a great day!

Fabian Pijcke